### PR TITLE
TS import alias for `@usevenice/web`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,6 @@
     "prefer-const": "warn",
     "quotes": ["warn", "single", {"avoidEscape": true}],
     "codegen/codegen": "warn",
-    "import/no-unresolved": "error",
     "eslint-comments/disable-enable-pair": "off",
     "eslint-comments/no-unlimited-disable": "off",
     "eslint-comments/no-unused-disable": "warn",
@@ -94,65 +93,5 @@
     "unicorn/require-number-to-fixed-digits-argument": "warn",
     "unicorn/template-indent": "warn",
     "unicorn/throw-new-error": "warn"
-  },
-  "overrides": [
-    {
-      "files": ["**/*.{ts,tsx}"],
-      "parserOptions": {
-        "project": "tsconfig.json"
-      },
-      "plugins": ["@typescript-eslint"],
-      "extends": ["plugin:@typescript-eslint/strict"],
-      "rules": {
-        "@typescript-eslint/array-type": ["warn", {"default": "array-simple"}],
-        "@typescript-eslint/await-thenable": "warn",
-        "@typescript-eslint/ban-ts-comment": "off",
-        "@typescript-eslint/ban-tslint-comment": "off",
-        "@typescript-eslint/ban-types": "off",
-        "@typescript-eslint/consistent-type-assertions": "warn",
-        "@typescript-eslint/consistent-type-imports": [
-          "warn",
-          {"disallowTypeAnnotations": false}
-        ],
-        "@typescript-eslint/no-empty-function": "off",
-        "@typescript-eslint/no-empty-interface": "off",
-        "@typescript-eslint/no-explicit-any": "warn",
-        "@typescript-eslint/no-extra-semi": "off",
-        "@typescript-eslint/no-floating-promises": "warn",
-        "@typescript-eslint/no-for-in-array": "warn",
-        "no-implied-eval": "off",
-        "@typescript-eslint/no-implied-eval": "warn",
-        "@typescript-eslint/no-invalid-void-type": "off",
-        "@typescript-eslint/no-non-null-assertion": "warn",
-        "@typescript-eslint/no-unnecessary-condition": "off",
-        "@typescript-eslint/no-unnecessary-type-assertion": "warn",
-        "@typescript-eslint/no-unsafe-argument": "warn",
-        "@typescript-eslint/no-unsafe-assignment": "warn",
-        "@typescript-eslint/no-unsafe-call": "warn",
-        "@typescript-eslint/no-unsafe-member-access": "warn",
-        "@typescript-eslint/no-unsafe-return": "warn",
-        "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/no-var-requires": "off",
-        "require-await": "off",
-        "@typescript-eslint/require-await": "warn",
-        "@typescript-eslint/restrict-plus-operands": "warn",
-        "@typescript-eslint/restrict-template-expressions": "off",
-        "@typescript-eslint/unbound-method": "warn"
-      }
-    },
-    {
-      "files": [
-        "**/__{mocks,tests}__/**/*.{js,ts,tsx}",
-        "**/*.{spec,test}.{js,ts,tsx}"
-      ],
-      "plugins": ["jest", "jest-formatting"],
-      "extends": [
-        "plugin:jest/recommended",
-        "plugin:jest-formatting/recommended"
-      ],
-      "rules": {
-        "jest/expect-expect": "off"
-      }
-    }
-  ]
+  }
 }

--- a/apps/app-config/commonConfig.ts
+++ b/apps/app-config/commonConfig.ts
@@ -3,7 +3,6 @@ import {joinPath, zParser} from '@usevenice/util'
 
 import {PROVIDERS, zCommonEnv} from './env'
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 export const commonEnv = zParser(zCommonEnv).parse({
   // Need to use fully qualified form of process.env.$VAR for
   // webpack DefineEnv that next.js uses to work
@@ -11,7 +10,6 @@ export const commonEnv = zParser(zCommonEnv).parse({
   NEXT_PUBLIC_SUPABASE_URL: process.env['NEXT_PUBLIC_SUPABASE_URL']!,
   NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']!,
 })
-/* eslint-enable @typescript-eslint/no-non-null-assertion */
 
 // TODO: Removing providers we are not using so we don't have nearly as much code, at least on the frontend!
 // Further perhaps code from supported providers can be loaded dynamically based on

--- a/apps/web/components/ConnectionCard.tsx
+++ b/apps/web/components/ConnectionCard.tsx
@@ -12,8 +12,8 @@ import {
 } from '@usevenice/ui'
 import {formatDateTime, sentenceCase} from '@usevenice/util'
 
-import {envAtom} from '../contexts/atoms'
-import {copyToClipboard} from '../contexts/common-contexts'
+import {envAtom} from '@usevenice/web/contexts/atoms'
+import {copyToClipboard} from '@usevenice/web/contexts/common-contexts'
 import {InstitutionLogo} from './InstitutionLogo'
 
 export interface ConnectionCardProps {

--- a/apps/web/components/EnhancedLink.tsx
+++ b/apps/web/components/EnhancedLink.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 
 import {parseUrl, shallowOmitUndefined} from '@usevenice/util'
 
-import {kAccessToken, kEnv} from '../contexts/atoms'
+import {kAccessToken, kEnv} from '@usevenice/web/contexts/atoms'
 
 export const EnhancedLink = React.forwardRef(function EnhancedLink(
   props: LinkProps &

--- a/apps/web/components/Layout.tsx
+++ b/apps/web/components/Layout.tsx
@@ -13,7 +13,7 @@ import {
 } from '@usevenice/ui'
 import {Container} from '@usevenice/ui/components/Container'
 
-import {developerModeAtom} from '../contexts/atoms'
+import {developerModeAtom} from '@usevenice/web/contexts/atoms'
 import {EnhancedActiveLink} from './EnhancedActiveLink'
 
 export interface LinkInput {

--- a/apps/web/components/common-components.tsx
+++ b/apps/web/components/common-components.tsx
@@ -1,6 +1,6 @@
 import {EffectContainer} from '@usevenice/ui'
 
-import {useRouterPlus} from '../contexts/atoms'
+import {useRouterPlus} from '@usevenice/web/contexts/atoms'
 import {LoadingIndicatorOverlay} from './loading-indicators'
 
 export function RedirectTo(props: {url: string}) {

--- a/apps/web/layouts/PageLayout/AccountMenu.tsx
+++ b/apps/web/layouts/PageLayout/AccountMenu.tsx
@@ -4,8 +4,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@usevenice/ui'
-import {supabase} from '../../contexts/common-contexts'
-import {useSession} from '../../contexts/session-context'
+import {supabase} from '@usevenice/web/contexts/common-contexts'
+import {useSession} from '@usevenice/web/contexts/session-context'
 import type {ComponentPropsWithoutRef} from 'react'
 
 export function AccountMenu() {

--- a/apps/web/layouts/PageLayout/AuthLayout.tsx
+++ b/apps/web/layouts/PageLayout/AuthLayout.tsx
@@ -2,10 +2,10 @@ import Image from 'next/image'
 import Link from 'next/link'
 import type {PropsWithChildren} from 'react'
 
-import {RedirectTo} from '../../components/common-components'
-import {EnhancedActiveLink} from '../../components/EnhancedActiveLink'
-import {LoadingIndicatorOverlay} from '../../components/loading-indicators'
-import {useSession} from '../../contexts/session-context'
+import {RedirectTo} from '@usevenice/web/components/common-components'
+import {EnhancedActiveLink} from '@usevenice/web/components/EnhancedActiveLink'
+import {LoadingIndicatorOverlay} from '@usevenice/web/components/loading-indicators'
+import {useSession} from '@usevenice/web/contexts/session-context'
 import {AccountMenu} from './AccountMenu'
 
 interface AuthLayoutProps extends PropsWithChildren {}

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,4 +1,4 @@
-import '../__generated__/tailwind.css'
+import '@usevenice/web/__generated__/tailwind.css'
 
 import {useAtomValue} from 'jotai'
 import {NextAdapter} from 'next-query-params'
@@ -15,9 +15,12 @@ import {veniceCommonConfig} from '@usevenice/app-config/commonConfig'
 import {VeniceProvider} from '@usevenice/engine-frontend'
 import {UIProvider} from '@usevenice/ui'
 
-import {accessTokenAtom, developerModeAtom} from '../contexts/atoms'
-import {supabase} from '../contexts/common-contexts'
-import {SessionContextProvider, useSession} from '../contexts/session-context'
+import {accessTokenAtom, developerModeAtom} from '@usevenice/web/contexts/atoms'
+import {supabase} from '@usevenice/web/contexts/common-contexts'
+import {
+  SessionContextProvider,
+  useSession,
+} from '@usevenice/web/contexts/session-context'
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/apps/web/pages/api/inngest.ts
+++ b/apps/web/pages/api/inngest.ts
@@ -1,7 +1,7 @@
-import {inngest} from '../../inngest/events'
+import {inngest} from '@usevenice/web/inngest/events'
 
 import {serve} from 'inngest/next'
-import * as functions from '../../inngest/functions'
+import * as functions from '@usevenice/web/inngest/functions'
 
 export default serve(inngest.name, Object.values(functions), {
   // serveHost: 'http://localhost:3010',

--- a/apps/web/pages/api/trpc/[...trpc].ts
+++ b/apps/web/pages/api/trpc/[...trpc].ts
@@ -14,7 +14,7 @@ import {
 import {baseRouter, parseWebhookRequest} from '@usevenice/engine-backend'
 import {fromMaybeArray, makeUlid, R, safeJSONParse, z} from '@usevenice/util'
 
-import {kAccessToken} from '../../../contexts/atoms'
+import {kAccessToken} from '@usevenice/web/contexts/atoms'
 
 export function getAccessToken(req: NextApiRequest) {
   return (
@@ -200,7 +200,7 @@ export default R.identity<NextApiHandler>((req, res) => {
       query: req.query,
       body: req.body,
     })
-    req.query = ret.query as typeof req['query']
+    req.query = ret.query as (typeof req)['query']
     req.query['trpc'] = procedure
     req.body = ret.body
   }

--- a/apps/web/pages/auth.tsx
+++ b/apps/web/pages/auth.tsx
@@ -2,11 +2,11 @@ import {Auth, ThemeSupa} from '@supabase/auth-ui-react'
 import {Container} from '@usevenice/ui'
 import Image from 'next/image'
 
-import {RedirectTo} from '../components/common-components'
-import {supabase} from '../contexts/common-contexts'
-import {useSession} from '../contexts/session-context'
-import {PageLayout} from '../layouts/PageLayout'
-import {VeniceTheme} from '../styles/themes'
+import {RedirectTo} from '@usevenice/web/components/common-components'
+import {supabase} from '@usevenice/web/contexts/common-contexts'
+import {useSession} from '@usevenice/web/contexts/session-context'
+import {PageLayout} from '@usevenice/web/layouts/PageLayout'
+import {VeniceTheme} from '@usevenice/web/styles/themes'
 
 export default function AuthScreen() {
   const [session] = useSession()

--- a/apps/web/pages/data.tsx
+++ b/apps/web/pages/data.tsx
@@ -11,10 +11,10 @@ import '@glideapps/glide-data-grid/dist/index.css'
 
 import {VeniceProvider} from '@usevenice/engine-frontend'
 
-import {copyToClipboard} from '../contexts/common-contexts'
-import {PageLayout} from '../layouts/PageLayout'
+import {copyToClipboard} from '@usevenice/web/contexts/common-contexts'
+import {PageLayout} from '@usevenice/web/layouts/PageLayout'
 
-import {VeniceDataGridTheme} from '../styles/themes'
+import {VeniceDataGridTheme} from '@usevenice/web/styles/themes'
 const DataEditor = dynamic(
   () => import('@glideapps/glide-data-grid').then((r) => r.DataEditor),
   {ssr: false},

--- a/apps/web/pages/pipelines.tsx
+++ b/apps/web/pages/pipelines.tsx
@@ -6,11 +6,11 @@ import Link from 'next/link'
 import type {Id} from '@usevenice/cdk-core'
 import {useVenice} from '@usevenice/engine-frontend'
 
-import {EnhancedActiveLink} from '../components/EnhancedActiveLink'
-import {envAtom, ledgerIdAtom, modeAtom} from '../contexts/atoms'
-import {ConnectionCard} from '../components/ConnectionCard'
-import {PageLayout} from '../layouts/PageLayout'
-import {NewPipelineInScreen} from '../screens/NewPipelineInScreen'
+import {EnhancedActiveLink} from '@usevenice/web/components/EnhancedActiveLink'
+import {envAtom, ledgerIdAtom, modeAtom} from '@usevenice/web/contexts/atoms'
+import {ConnectionCard} from '@usevenice/web/components/ConnectionCard'
+import {PageLayout} from '@usevenice/web/layouts/PageLayout'
+import {NewPipelineInScreen} from '@usevenice/web/screens/NewPipelineInScreen'
 
 export default function PipelinesScreen() {
   const mode = useAtomValue(modeAtom)

--- a/apps/web/screens/NewPipelineInScreen.tsx
+++ b/apps/web/screens/NewPipelineInScreen.tsx
@@ -17,9 +17,9 @@ import {
 } from '@usevenice/ui'
 import {R} from '@usevenice/util'
 
-import {InstitutionLogo} from '../components/InstitutionLogo'
-import {envAtom, modeAtom, searchByAtom} from '../contexts/atoms'
-import {LoadingIndicator} from '../components/loading-indicators'
+import {InstitutionLogo} from '@usevenice/web/components/InstitutionLogo'
+import {envAtom, modeAtom, searchByAtom} from '@usevenice/web/contexts/atoms'
+import {LoadingIndicator} from '@usevenice/web/components/loading-indicators'
 
 type ConnectMode = 'institution' | 'provider'
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,7 +12,11 @@
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@usevenice/web/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
### What
Add import alias `@usevenice/web` to use in `apps/web`.

### Motivation
Ergonomic for import; IDE autocomplete. Less reliant on relative path of other modules.