### PR TITLE
fix: server-side error on export page when user not authed

### DIFF
--- a/apps/web/components/export/PreviewResult.tsx
+++ b/apps/web/components/export/PreviewResult.tsx
@@ -10,22 +10,7 @@ export function PreviewResult(props: PreviewQuery) {
   const {headings, rows, totalCount} = data
 
   if (isInitial) {
-    return isFetching ? (
-      <LoadingPreviewResult />
-    ) : (
-      <EmptyPreviewResult
-        title="Select a table to export from!"
-        action={
-          <p className="max-w-[14rem] text-center">
-            <Link
-              className="text-venice-green hover:text-venice-green-darkened"
-              href="/connections">
-              Or, connect more financial institutions.
-            </Link>
-          </p>
-        }
-      />
-    )
+    return <LoadingPreviewResult />
   }
 
   if (rows.length === 0) {

--- a/apps/web/pages/export.tsx
+++ b/apps/web/pages/export.tsx
@@ -37,6 +37,14 @@ export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (
 ) => {
   const {serverGetUser} = await import('../server')
   const user = await serverGetUser(ctx)
+  if (!user?.id) {
+    return {
+      redirect: {
+        destination: '/auth',
+        permanent: false,
+      },
+    }
+  }
 
   const {z} = await import('@usevenice/util')
   const apiKey = z.string().parse(user?.user_metadata?.['apiKey'])

--- a/apps/web/pages/export.tsx
+++ b/apps/web/pages/export.tsx
@@ -47,7 +47,7 @@ export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (
   }
 
   const {z} = await import('@usevenice/util')
-  const apiKey = z.string().parse(user?.user_metadata?.['apiKey'])
+  const apiKey = z.string().parse(user.user_metadata['apiKey'])
   const serverUrl = commonEnv.NEXT_PUBLIC_SERVER_URL
 
   return {


### PR DESCRIPTION
Fix so that the app doesn't throw uncaught exception during `getServerSideProps` for `/export` page when user is not authenticated.