### PR TITLE
[Connections] Better UX when updating institution names

### DIFF
--- a/apps/web/components/connections/ConnectionCard/ConnectionCard.tsx
+++ b/apps/web/components/connections/ConnectionCard/ConnectionCard.tsx
@@ -1,9 +1,7 @@
-import type {Id} from '@usevenice/cdk-core'
 import {VeniceProvider} from '@usevenice/engine-frontend'
 import {DialogPrimitive as Dialog, Loading} from '@usevenice/ui'
 import {
   CircleFilledIcon,
-  CloseIcon,
   DeleteIcon,
   EditIcon,
   SyncIcon,
@@ -11,12 +9,12 @@ import {
 import clsx from 'clsx'
 import {formatDistanceToNowStrict} from 'date-fns'
 import Image from 'next/image'
-import {forwardRef, useEffect, useRef, useState} from 'react'
+import {forwardRef, useState} from 'react'
 import type {Connection} from '../../../lib/supabase-queries'
-import {mutations} from '../../../lib/supabase-queries'
 import {ResourceCard} from '../../ResourceCard'
 import {ActionMenu, ActionMenuItem} from './ActionMenu'
 import {DeleteConnectionDialog} from './DeleteConnectionDialog'
+import {EditingDisplayName} from './EditingDisplayName'
 
 export interface ConnectionCardProps {
   connection: Connection
@@ -146,66 +144,6 @@ export const ConnectionCard = forwardRef<HTMLDivElement, ConnectionCardProps>(
     )
   },
 )
-
-interface EditingDisplayNameProps {
-  displayName: string
-  onCancel: () => void
-  onUpdateSuccess: () => void
-  resourceId: Id['reso']
-}
-
-function EditingDisplayName(props: EditingDisplayNameProps) {
-  const {onCancel, onUpdateSuccess, resourceId} = props
-  const [displayName, setDisplayName] = useState(props.displayName)
-  const updateResource = mutations.useUpdateResource()
-
-  useEffect(() => {
-    async function handleKeyDown(event: KeyboardEvent) {
-      switch (event.key) {
-        case 'Escape':
-          onCancel()
-          break
-        case 'Enter':
-          // TODO show loading state on mutation.isLoading
-          await updateResource.mutateAsync({
-            id: resourceId,
-            display_name: displayName,
-          })
-          onUpdateSuccess()
-          break
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [displayName, onCancel, onUpdateSuccess, resourceId, updateResource])
-
-  const inputRef = useRef<HTMLInputElement>(null)
-  useEffect(() => {
-    // HACK: don't know why but doing it sync or with 0 timeout doesn't work
-    // using autoFocus props on input also doesn't work. It might have
-    // something to do with radix dropdown focus management.
-    setTimeout(() => inputRef.current?.focus(), 100)
-  }, [inputRef])
-
-  return (
-    <div className="relative flex grow items-center gap-2 rounded bg-venice-black px-2 py-1 focus-within:ring-1 focus-within:ring-inset focus-within:ring-venice-green">
-      <input
-        ref={inputRef}
-        value={displayName}
-        onChange={(event) => setDisplayName(event.target.value)}
-        className="grow appearance-none bg-transparent text-sm text-offwhite focus:outline-none"
-      />
-      <button
-        className="h-4 w-4 shrink-0 rounded-full fill-current p-1 text-white hover:bg-offwhite/20 focus:outline-none focus-visible:bg-offwhite/20"
-        onClick={onCancel}>
-        <CloseIcon />
-      </button>
-    </div>
-  )
-}
 
 function ConnectionStatus({status}: {status: ConnectionStatus}) {
   const {color, text} =

--- a/apps/web/components/connections/ConnectionCard/EditingDisplayName.tsx
+++ b/apps/web/components/connections/ConnectionCard/EditingDisplayName.tsx
@@ -1,0 +1,120 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query'
+import type {Id} from '@usevenice/cdk-core'
+import {CircularProgress} from '@usevenice/ui'
+import {CloseIcon} from '@usevenice/ui/icons'
+import clsx from 'clsx'
+import {useEffect, useRef, useState} from 'react'
+import {browserSupabase} from '../../../contexts/common-contexts'
+import {useOnClickOutside} from '../../../hooks/useOnClickOutside'
+
+interface EditingDisplayNameProps {
+  displayName: string
+  onCancel: () => void
+  onUpdateSuccess: () => void
+  resourceId: Id['reso']
+}
+
+export function EditingDisplayName(props: EditingDisplayNameProps) {
+  const {onCancel, onUpdateSuccess, resourceId} = props
+  const [displayName, setDisplayName] = useState(props.displayName)
+
+  const queryClient = useQueryClient()
+  const {mutate: updateDisplayName, isLoading: isUpdating} = useMutation(
+    async () => {
+      const {error} = await browserSupabase
+        .from('resource')
+        .update({display_name: displayName})
+        .eq('id', resourceId)
+
+      if (error) {
+        throw new Error(error.message)
+      }
+      return undefined
+    },
+    {
+      mutationKey: ['resource', 'update', resourceId],
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: ['connections', 'list'],
+        })
+        onUpdateSuccess()
+      },
+      // TEMPORARY
+      onError: console.error,
+    },
+  )
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    // HACK: don't know why but doing it sync or with 0 timeout doesn't work
+    // using autoFocus props on input also doesn't work. It might have
+    // something to do with radix dropdown focus management.
+    setTimeout(() => inputRef.current?.focus(), 100)
+  }, [inputRef])
+
+  // pass only the mutate function to the effect below rather than
+  // the entire mutation object to avoid the effect being re-mount
+  // for each change to displayName.
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (isUpdating) {
+        return
+      }
+      switch (event.key) {
+        case 'Escape':
+          onCancel()
+          break
+        case 'Enter':
+          updateDisplayName({})
+          break
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isUpdating, onCancel, updateDisplayName])
+
+  useOnClickOutside(inputRef, () => updateDisplayName({}))
+
+  return (
+    <div
+      className={clsx(
+        'relative flex grow items-center gap-2 rounded bg-venice-black px-2 py-1 focus-within:ring-1 focus-within:ring-inset',
+        isUpdating
+          ? 'focus-within:ring-venice-green/50'
+          : 'focus-within:ring-venice-green',
+      )}>
+      <input
+        ref={inputRef}
+        value={displayName}
+        onChange={(event) => setDisplayName(event.target.value)}
+        className={clsx(
+          'grow appearance-none bg-transparent text-sm focus:outline-none',
+          isUpdating ? 'text-offwhite/70' : 'text-offwhite',
+        )}
+        disabled={isUpdating}
+      />
+      {isUpdating ? (
+        <CircularProgress className="h-3 w-3 fill-offwhite text-offwhite/50" />
+      ) : (
+        <CloseButton onClick={onCancel} />
+      )}
+    </div>
+  )
+}
+
+interface CloseButtonProps {
+  onClick: () => void
+}
+
+function CloseButton(props: CloseButtonProps) {
+  return (
+    <button
+      className="h-4 w-4 shrink-0 rounded-full fill-current p-1 text-white hover:bg-offwhite/20 focus:outline-none focus-visible:bg-offwhite/20"
+      onClick={props.onClick}>
+      <CloseIcon />
+    </button>
+  )
+}

--- a/apps/web/hooks/useOnClickOutside.ts
+++ b/apps/web/hooks/useOnClickOutside.ts
@@ -1,0 +1,35 @@
+import type {RefObject} from 'react'
+import {useEffect, useRef, useCallback} from 'react'
+
+export function useOnClickOutside(
+  targetElementRef: RefObject<HTMLElement | null>,
+  handler: (event: Event) => void,
+): void {
+  const savedHandler = useRef(handler)
+  // keep reference to handler up-to-date but don't re-create
+  // handleClick so we don't re-mount everytime handler changes
+  useEffect(() => {
+    savedHandler.current = handler
+  }, [handler])
+
+  const el = targetElementRef?.current
+  const handleClick = useCallback(
+    (event: Event) => {
+      const {target} = event
+      if (target instanceof Node && el && !el.contains(target)) {
+        // handler(event)
+        savedHandler.current(event)
+      }
+    },
+    [el],
+  )
+
+  useEffect(() => {
+    document.addEventListener('click', handleClick, true)
+    document.addEventListener('ontouchstart', handleClick, true)
+    return () => {
+      document.removeEventListener('click', handleClick, true)
+      document.removeEventListener('ontouchstart', handleClick, true)
+    }
+  }, [handleClick])
+}

--- a/apps/web/lib/supabase-queries.ts
+++ b/apps/web/lib/supabase-queries.ts
@@ -148,35 +148,6 @@ export const queries = {
 // MARK: - Mutations
 
 export const mutations = {
-  useUpdateResource: () =>
-    useMutation(
-      async ({
-        id,
-        ...update
-      }: Database['public']['Tables']['resource']['Update'] & {
-        id: Id['reso']
-      }) => browserSupabase.from('resource').update(update).eq('id', id),
-      {
-        // TODO: Consider optimistic update
-        // Unfortunately we don't have access to the variables at render time
-        // If we need a mutationKey per pipeline update we are gonna have to call
-        // useUpdateResource within PipelineCard or something similar.
-        // @see https://share.cleanshot.com/Px624f99
-        mutationKey: ['updateResource'],
-
-        // Consider updating query data directly rather than invalidating
-        // This is no longer necessary due to supabase realtime sub
-        // However due to network sometimes times changes may actually get missed
-        // therefore we still need this for now to be sure
-        // We should figure out why react query is not deduplicating the requests though
-        // They seem to fire one another
-        // onSuccess: () =>
-        //   queryClient.invalidateQueries(
-        //     getQueryKeys(browserSupabase).pipelines._def,
-        //   ),
-      },
-    ),
-
   useDeletePipeline: () =>
     useMutation(
       async ({

--- a/apps/web/pages/connections.page.tsx
+++ b/apps/web/pages/connections.page.tsx
@@ -1,4 +1,3 @@
-import {ArcherContainer, ArcherElement} from 'react-archer'
 import type {ConnectWith, Id, UserId} from '@usevenice/cdk-core'
 import type {UseVenice} from '@usevenice/engine-frontend'
 import {useVenice} from '@usevenice/engine-frontend'
@@ -9,6 +8,7 @@ import type {GetServerSideProps} from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'
+import {ArcherContainer, ArcherElement} from 'react-archer'
 import {ConnectionCard, ConnectionCardSkeleton} from '../components/connections'
 import {PageHeader} from '../components/PageHeader'
 import {PageLayout} from '../components/PageLayout'
@@ -17,7 +17,7 @@ import {modeAtom} from '../contexts/atoms'
 import type {Connection} from '../lib/supabase-queries'
 import {getQueryKeys, queries} from '../lib/supabase-queries'
 import type {PageProps} from '../server'
-import {createSSRHelpers} from '../server'
+import {createSSRHelpers, ensureDefaultLedger} from '../server'
 
 const VENICE_DATABASE_IMAGE_ID = 'venice-database-image'
 
@@ -55,7 +55,6 @@ export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (
     ),
   )
 
-  const {ensureDefaultLedger} = await import('../server')
   const ledgerIds = await ensureDefaultLedger(user.id)
   return {
     props: {
@@ -67,8 +66,7 @@ export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (
 }
 
 export default function ConnectionsPage(props: ServerSideProps) {
-  const res = queries.useConnectionsList()
-
+  const connections = queries.useConnectionsList()
   return (
     <PageLayout title="Connections">
       <div className="grid min-h-screen grid-rows-[auto_1fr]">
@@ -79,11 +77,11 @@ export default function ConnectionsPage(props: ServerSideProps) {
           strokeWidth={2}
           endMarker={false}>
           <div className="flex gap-36 p-16">
-            {res.isLoading ? (
+            {connections.isLoading ? (
               <LoadingConnectionsColumn />
             ) : (
               <ConnectionsColumn
-                connections={res.data?.source ?? []}
+                connections={connections.data?.source ?? []}
                 connectWith={{destinationId: props.ledgerIds[0]}}
               />
             )}


### PR DESCRIPTION
### What
- add loading state to show when the bank renaming is being saved (to the api) + disable input and graying out text
- clicking outside of the input while editing saves the result
- disable both save and cancel while updating is in-flight to prevent race condition
- invalidate query on rename to show the updated data once received response from the API
- eliminate excessive unmount/re-mount on every keystroke which causes event handlers to be unbound and rebound

Overall, I think the UX is much better now. Quite happy about it.

https://user-images.githubusercontent.com/3942264/219635400-7c27fec1-07ea-4ec3-b7d4-96171d2751be.mov

