### PR TITLE
fix: [Connections] delete connection doesn't update UI

### DIFF
--- a/apps/web/components/connections/ConnectionCard/DeleteConnectionDialog.tsx
+++ b/apps/web/components/connections/ConnectionCard/DeleteConnectionDialog.tsx
@@ -1,21 +1,19 @@
-import type {Id, ZStandard} from '@usevenice/cdk-core'
+import type {ZStandard} from '@usevenice/cdk-core'
 import {DialogPrimitive as Dialog} from '@usevenice/ui'
 import {DeleteIcon} from '@usevenice/ui/icons'
 import Image from 'next/image'
 import type {Connection} from '../../../lib/supabase-queries'
-import {mutations} from '../../../lib/supabase-queries'
 
 interface DeleteConnectionDialogProps {
   institution?: ZStandard['institution'] | null
+  isDeleting?: boolean
   name?: Connection['resource']['displayName']
   onCancel: () => void
-  pipelineId: Id['pipe']
-  resourceId: Id['reso']
+  onDeletionConfirmed: () => void
 }
 
 export function DeleteConnectionDialog(props: DeleteConnectionDialogProps) {
-  const {institution, name, onCancel, pipelineId, resourceId} = props
-  const deletePipeline = mutations.useDeletePipeline()
+  const {institution, isDeleting, name, onCancel, onDeletionConfirmed} = props
   return (
     <Dialog.Portal>
       <div className="fixed inset-0 z-50 flex items-start justify-center sm:items-center">
@@ -58,17 +56,11 @@ export function DeleteConnectionDialog(props: DeleteConnectionDialogProps) {
               Cancel
             </button>
             <button
-              onClick={() => deletePipeline.mutate({pipelineId, resourceId})}
-              // TODO fix the dialog shows a second of non-disabled button
-              // after deletePipeline is done.
-              disabled={deletePipeline.isLoading}
+              onClick={onDeletionConfirmed}
+              disabled={isDeleting}
               className="flex min-w-[6rem] items-center gap-2 rounded-lg bg-venice-red px-3 py-2 text-sm text-offwhite hover:bg-[#ac2039] focus:outline-none focus-visible:bg-[#ac2039] disabled:opacity-30 disabled:hover:bg-venice-red">
               <DeleteIcon className="h-4 w-4 fill-current" />
-              {deletePipeline.isLoading ? (
-                <span>Deleting…</span>
-              ) : (
-                <span>Delete</span>
-              )}
+              {isDeleting ? <span>Deleting…</span> : <span>Delete</span>}
             </button>
           </div>
         </Dialog.Content>

--- a/apps/web/components/connections/ConnectionCard/EditingDisplayName.tsx
+++ b/apps/web/components/connections/ConnectionCard/EditingDisplayName.tsx
@@ -1,4 +1,4 @@
-import {useMutation, useQueryClient} from '@tanstack/react-query'
+import {useMutation} from '@tanstack/react-query'
 import type {Id} from '@usevenice/cdk-core'
 import {CircularProgress} from '@usevenice/ui'
 import {CloseIcon} from '@usevenice/ui/icons'
@@ -10,15 +10,15 @@ import {useOnClickOutside} from '../../../hooks/useOnClickOutside'
 interface EditingDisplayNameProps {
   displayName: string
   onCancel: () => void
+  onConnectionsMutated: () => Promise<void>
   onUpdateSuccess: () => void
   resourceId: Id['reso']
 }
 
 export function EditingDisplayName(props: EditingDisplayNameProps) {
-  const {onCancel, onUpdateSuccess, resourceId} = props
+  const {onCancel, onConnectionsMutated, onUpdateSuccess, resourceId} = props
   const [displayName, setDisplayName] = useState(props.displayName)
 
-  const queryClient = useQueryClient()
   const {mutate: updateDisplayName, isLoading: isUpdating} = useMutation(
     async () => {
       const {error} = await browserSupabase
@@ -34,9 +34,7 @@ export function EditingDisplayName(props: EditingDisplayNameProps) {
     {
       mutationKey: ['resource', 'update', resourceId],
       onSuccess: async () => {
-        await queryClient.invalidateQueries({
-          queryKey: ['connections', 'list'],
-        })
+        await onConnectionsMutated()
         onUpdateSuccess()
       },
       // TEMPORARY

--- a/apps/web/lib/supabase-queries.ts
+++ b/apps/web/lib/supabase-queries.ts
@@ -148,27 +148,6 @@ export const queries = {
 // MARK: - Mutations
 
 export const mutations = {
-  useDeletePipeline: () =>
-    useMutation(
-      async ({
-        pipelineId,
-        resourceId,
-      }: {
-        pipelineId: Id['pipe']
-        resourceId: Id['reso']
-      }) => {
-        await browserSupabase.from('pipeline').delete().eq('id', pipelineId)
-        // TODO: Need to properly handle this on the server to
-        // 1) Remove orphan resource
-        // 2) Revoke before deleting as needed
-        if (resourceId.includes('debug')) {
-          await browserSupabase.from('resource').delete().eq('id', resourceId)
-        }
-      },
-      // TODO: Revoke & remove the resources as pipelines are deleted
-      // We should have a background job for this probably...
-    ),
-
   useCreateDummySource: ({
     ledgerId,
     userId,


### PR DESCRIPTION
[Connections page] Fixes:
- deleting a connection doesn't update the "sources" column (cause: does not invalidate query - i.e. refetch)
- deleting a connection left the modal open 

## Broken

https://user-images.githubusercontent.com/3942264/219866349-60ea960f-e7c7-4238-bbfe-da0256972d85.mov

## Fixed

https://user-images.githubusercontent.com/3942264/219866680-986969a8-db86-447d-9172-d34a7c84e261.mov
